### PR TITLE
UX: remove discourse-bookmark-clock because there's no pro alternative

### DIFF
--- a/assets/javascripts/initializers/replacements.js
+++ b/assets/javascripts/initializers/replacements.js
@@ -40,7 +40,6 @@ export default {
         "book",
         "book-reader",
         "bookmark",
-        "discourse-bookmark-clock",
         "briefcase",
         "calendar-alt",
         "caret-down",


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/bookmark-clock-icon-broken-after-changing-icon-set/240402

The "discourse-bookmark-clock" icon is a custom derivative and there's no pro alternative... so it's best to remove the replacement and rely on the default icon (it currently appears blank). 

Unfortunately we can't build a pro alternative for this icon, because I don't think we can't modify the pro icons without violating the fontawesome pro license. 