### PR TITLE
Remove `raise_on_fail: false` recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ hooks:
           - git clone https://github.com/discourse/discourse-fontawesome-pro.git
     - exec:
         cd: $home/plugins/discourse-fontawesome-pro
-        raise_on_fail: false
         cmd:
           - $home/plugins/discourse-fontawesome-pro/scripts/install.sh
 ```


### PR DESCRIPTION
If the `yarn install` fails, then that means the icons will not be installed, and the site UI may be broken. Better to bail out of the deploy, so the failure can be investigated.