### PR TITLE
DEV: update globe-americas to earth-americas icon name

### DIFF
--- a/assets/javascripts/initializers/replacements.js
+++ b/assets/javascripts/initializers/replacements.js
@@ -87,7 +87,7 @@ export default {
         "gavel",
         "gear",
         "globe",
-        "globe-americas",
+        "earth-americas",
         "hand-point-right",
         "handshake-angle",
         "heading",

--- a/lib/register_icons.rb
+++ b/lib/register_icons.rb
@@ -80,7 +80,7 @@ module RegisterIcons
       gavel
       gear
       globe
-      globe-americas
+      earth-americas
       hand-point-right
       handshake-angle
       heading


### PR DESCRIPTION
This updates the deprecated globe-americas name to earth-americas.